### PR TITLE
Fix Windows build and warnings.

### DIFF
--- a/Plugins/WebSocket/Source/WebSocket/Private/WebSocketBase.cpp
+++ b/Plugins/WebSocket/Source/WebSocket/Private/WebSocketBase.cpp
@@ -25,6 +25,10 @@
 
 #if PLATFORM_UWP
 #elif PLATFORM_HTML5
+#elif PLATFORM_WINDOWS 
+#include "PreWindowsApi.h"
+#include "libwebsockets.h"
+#include "PostWindowsApi.h" 
 #else
 #include "libwebsockets.h"
 #endif

--- a/Plugins/WebSocket/Source/WebSocket/Private/WebSocketContext.h
+++ b/Plugins/WebSocket/Source/WebSocket/Private/WebSocketContext.h
@@ -26,6 +26,10 @@
 
 #if PLATFORM_UWP
 #elif PLATFORM_HTML5
+#elif PLATFORM_WINDOWS  
+#include "PreWindowsApi.h"
+#include "libwebsockets.h"
+#include "PostWindowsApi.h" 
 #else
 #include "libwebsockets.h"
 #endif


### PR DESCRIPTION
Include PreWindowsApi.h and PostWindowsApi.h to fix macro redefinition warnings and build failures on Windows.
