### PR TITLE
Make websockets available for 4.23

### DIFF
--- a/Plugins/WebSocket/Source/WebSocket/WebSocket.Build.cs
+++ b/Plugins/WebSocket/Source/WebSocket/WebSocket.Build.cs
@@ -105,9 +105,9 @@ public class WebSocket : ModuleRules
                     PublicAdditionalLibraries.Add(Lib);
                 }
             }
-            else if(EngineMinorVersion == "22")
+            else if(EngineMinorVersion == "22" || EngineMinorVersion == "23")
             {
-                // for 4.22
+                // for 4.22 and 4.23
                 if (Target.Type == TargetType.Editor)
                 {
                     PublicAdditionalLibraries.Add("websockets_static422.lib");
@@ -146,7 +146,7 @@ public class WebSocket : ModuleRules
                     PublicAdditionalLibraries.Add(Lib);
                 }
             }
-            else if(EngineMinorVersion == "22")
+            else if(EngineMinorVersion == "22"|| EngineMinorVersion == "23")
             {
                 string[] StaticLibrariesX32 = new string[] {
                     "websockets_static422.lib",

--- a/UEWebsocket.uproject
+++ b/UEWebsocket.uproject
@@ -1,6 +1,6 @@
 {
 	"FileVersion": 3,
-	"EngineAssociation": "4.22",
+	"EngineAssociation": "4.23",
 	"Category": "",
 	"Description": "",
 	"Modules": [


### PR DESCRIPTION
Makes UE4Websocket available to 4.23 users. It has been roughly tested on Win64 with the included project. So far everything seems to be working